### PR TITLE
Experimental: Mixture of logistic distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This is still much WIP. See https://github.com/r9y9/wavenet_vocoder/issues/1 for
 
 ## Highlights
 
-- Focus on local and global conditioning of WaveNet, which is essential to use it as a vocoder.
+- Focus on local and global conditioning of WaveNet, which is essential for vocoder.
+- Mixture of logistic distributions loss / sampling (experimental)
 
 ## Requirements
 

--- a/cmu_arctic.py
+++ b/cmu_arctic.py
@@ -70,7 +70,7 @@ def _process_utterance(out_dir, index, speaker_id, wav_path, text):
         wav, _ = librosa.effects.trim(wav, top_db=20)
 
     # Mu-law quantize
-    quantized = P.mulaw_quantize(wav)
+    quantized = P.mulaw_quantize(wav, hparams.quantize_channels)
 
     # Trim silences
     start, end = audio.start_and_end_indices(quantized, hparams.silence_threshold)
@@ -86,7 +86,7 @@ def _process_utterance(out_dir, index, speaker_id, wav_path, text):
 
     # zero pad for quantized signal
     quantized = np.pad(quantized, (l, r), mode="constant",
-                       constant_values=P.mulaw_quantize(0))
+                       constant_values=P.mulaw_quantize(0, quantize_channels))
     N = mel_spectrogram.shape[0]
     assert len(quantized) >= N * audio.get_hop_size()
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -28,6 +28,9 @@ from keras.utils import np_utils
 from tqdm import tqdm
 import librosa
 
+
+from wavenet_vocoder.util import is_mulaw_quantize, is_mulaw, is_raw
+
 import audio
 from hparams import hparams
 
@@ -119,8 +122,10 @@ if __name__ == "__main__":
 
         # save
         librosa.output.write_wav(dst_wav_path, waveform, sr=hparams.sample_rate)
-        if hparams.mulaw:
-            x = P.inv_mulaw_quantize(x)
+        if is_mulaw_quantize(hparams.input_type):
+            x = P.inv_mulaw_quantize(x, hparams.quantize_channels)
+        elif is_mulaw(hparams.input_type):
+            x = P.inv_mulaw(x, hparams.quantize_channels)
         librosa.output.write_wav(target_wav_path, x, sr=hparams.sample_rate)
 
         # log

--- a/evaluate.py
+++ b/evaluate.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     speaker_id = args["--speaker-id"]
     speaker_id = int(speaker_id) if speaker_id is not None else None
     initial_value = args["--initial-value"]
-    initial_value = None if initial_value is None else int(initial_value)
+    initial_value = None if initial_value is None else float(initial_value)
     file_name_suffix = args["--file-name-suffix"]
     output_html = args["--output-html"]
     num_utterances = int(args["--num-utterances"])
@@ -119,8 +119,9 @@ if __name__ == "__main__":
 
         # save
         librosa.output.write_wav(dst_wav_path, waveform, sr=hparams.sample_rate)
-        librosa.output.write_wav(target_wav_path, P.inv_mulaw_quantize(x),
-                                 sr=hparams.sample_rate)
+        if hparams.mulaw:
+            x = P.inv_mulaw_quantize(x)
+        librosa.output.write_wav(target_wav_path, x, sr=hparams.sample_rate)
 
         # log
         if output_html:

--- a/hparams.py
+++ b/hparams.py
@@ -16,12 +16,16 @@ hparams = tf.contrib.training.HParams(
     presets={
     },
 
-    # If mulaw is True, audio signal in [-1, 1] is mu-law quantized to
-    # [0, quantize_channels), conveted to one-hot vector and
-    # then fed to the network, otherwise fed directly to the network.
-    # NOTE: if you change the one of the two parameters below, then you need to
-    # re-run preprocessing.
-    mulaw=False,
+    # Input type:
+    # 1. raw [-1, 1]
+    # 2. mulaw [-1, 1]
+    # 3. mulaw-quantize [0, mu]
+    # If input_type is raw or mulaw, network assumes scalar input and
+    # discretized mixture of logistic distributions output, otherwise one-hot
+    # input and softmax output are assumed.
+    # **NOTE**: if you change the one of the two parameters below, you need to
+    # re-run preprocessing before training.
+    input_type="mulaw",
     quantize_channels=256,  # 65536 or 256
 
     # Audio:
@@ -37,9 +41,9 @@ hparams = tf.contrib.training.HParams(
     ref_level_db=20,
 
     # Model:
-    # This should equal to `quantize_channels` if mulaw enabled
+    # This should equal to `quantize_channels` if mu-law quantize enabled
     # otherwise num_mixture * 3 (pi, mean, log_scale)
-    out_channels=10 * 3,
+    out_channels=5 * 3,
     layers=20,
     stacks=2,
     residual_channels=512,
@@ -84,8 +88,9 @@ hparams = tf.contrib.training.HParams(
     adam_beta2=0.999,
     adam_eps=1e-8,
     initial_learning_rate=1e-3,
+    # see lrschedule.py for available lr_schedule
     lr_schedule="noam_learning_rate_decay",
-    lr_schedule_kwargs={},
+    lr_schedule_kwargs={},  # {"anneal_rate": 0.5, "anneal_interval": 50000},
     nepochs=2000,
     weight_decay=0.0,
     clip_thresh=1.0,

--- a/hparams.py
+++ b/hparams.py
@@ -98,7 +98,7 @@ hparams = tf.contrib.training.HParams(
     # Save
     # per-step intervals
     checkpoint_interval=10000,
-    train_eval_interval=3000,
+    train_eval_interval=10000,
     # per-epoch interval
     test_eval_epoch_interval=5,
     save_optimizer_state=True,

--- a/hparams.py
+++ b/hparams.py
@@ -25,11 +25,11 @@ hparams = tf.contrib.training.HParams(
     # input and softmax output are assumed.
     # **NOTE**: if you change the one of the two parameters below, you need to
     # re-run preprocessing before training.
-    input_type="mulaw",
-    quantize_channels=256,  # 65536 or 256
+    input_type="raw",
+    quantize_channels=65536,  # 65536 or 256
 
     # Audio:
-    sample_rate=16000,
+    sample_rate=22050,
     # this is only valid for mulaw is True
     silence_threshold=2,
     num_mels=80,
@@ -83,7 +83,7 @@ hparams = tf.contrib.training.HParams(
     # Loss
 
     # Training:
-    batch_size=2,
+    batch_size=4,
     adam_beta1=0.9,
     adam_beta2=0.999,
     adam_eps=1e-8,

--- a/hparams.py
+++ b/hparams.py
@@ -25,6 +25,7 @@ hparams = tf.contrib.training.HParams(
     # input and softmax output are assumed.
     # **NOTE**: if you change the one of the two parameters below, you need to
     # re-run preprocessing before training.
+    # **NOTE**: scaler input (raw or mulaw) is experimental. Use it your own risk.
     input_type="raw",
     quantize_channels=65536,  # 65536 or 256
 

--- a/hparams.py
+++ b/hparams.py
@@ -26,8 +26,8 @@ hparams = tf.contrib.training.HParams(
     # **NOTE**: if you change the one of the two parameters below, you need to
     # re-run preprocessing before training.
     # **NOTE**: scaler input (raw or mulaw) is experimental. Use it your own risk.
-    input_type="raw",
-    quantize_channels=65536,  # 65536 or 256
+    input_type="mulaw-quantize",
+    quantize_channels=256,  # 65536 or 256
 
     # Audio:
     sample_rate=22050,
@@ -67,7 +67,7 @@ hparams = tf.contrib.training.HParams(
     # otherwise repeat features to adjust time resolution
     upsample_conditional_features=True,
     # should np.prod(upsample_scales) == hop_size
-    upsample_scales=[16, 16],
+    upsample_scales=[4, 4, 4, 4],
     # Freq axis kernel size for upsampling network
     freq_axis_kernel_size=3,
 

--- a/hparams.py
+++ b/hparams.py
@@ -43,7 +43,7 @@ hparams = tf.contrib.training.HParams(
     # Model:
     # This should equal to `quantize_channels` if mu-law quantize enabled
     # otherwise num_mixture * 3 (pi, mean, log_scale)
-    out_channels=5 * 3,
+    out_channels=10 * 3,
     layers=20,
     stacks=2,
     residual_channels=512,

--- a/hparams.py
+++ b/hparams.py
@@ -29,6 +29,7 @@ hparams = tf.contrib.training.HParams(
     ref_level_db=20,
 
     # Model:
+    out_channels=256,
     layers=20,
     stacks=2,
     residual_channels=512,

--- a/hparams.py
+++ b/hparams.py
@@ -34,12 +34,18 @@ hparams = tf.contrib.training.HParams(
     # this is only valid for mulaw is True
     silence_threshold=2,
     num_mels=80,
+    fmin=125,
+    fmax=7600,
     fft_size=1024,
     # shift can be specified by either hop_size or frame_shift_ms
     hop_size=256,
     frame_shift_ms=None,
     min_level_db=-100,
     ref_level_db=20,
+    # mel-spectrogram is normalized to [0, 1] for each utterance and clipping may
+    # happen depends on min_level_db and ref_level_db, causing clipping noise.
+    # If False, assertion is added to ensure no clipping happens.
+    allow_clipping_in_normalization=False,
 
     # Model:
     # This should equal to `quantize_channels` if mu-law quantize enabled

--- a/hparams.py
+++ b/hparams.py
@@ -17,7 +17,8 @@ hparams = tf.contrib.training.HParams(
     },
 
     # Audio:
-    sample_rate=16000,
+    quantize_channels=256,
+    sample_rate=22050,
     silence_threshold=2,
     num_mels=80,
     fft_size=1024,
@@ -28,9 +29,9 @@ hparams = tf.contrib.training.HParams(
     ref_level_db=20,
 
     # Model:
-    layers=16,
+    layers=20,
     stacks=2,
-    residual_channels=256,
+    residual_channels=512,
     gate_channels=512,  # split into 2 gropus internally for gated activation
     skip_out_channels=256,
     dropout=1 - 0.95,
@@ -67,7 +68,7 @@ hparams = tf.contrib.training.HParams(
     # Loss
 
     # Training:
-    batch_size=1,
+    batch_size=2,
     adam_beta1=0.9,
     adam_beta2=0.999,
     adam_eps=1e-8,
@@ -81,7 +82,7 @@ hparams = tf.contrib.training.HParams(
     # This is needed for those who don't have huge GPU memory...
     # if both are None, then full audio samples are used
     max_time_sec=None,
-    max_time_steps=20000,
+    max_time_steps=8000,
 
     # Save
     # per-step intervals

--- a/hparams.py
+++ b/hparams.py
@@ -16,9 +16,17 @@ hparams = tf.contrib.training.HParams(
     presets={
     },
 
+    # If mulaw is True, audio signal in [-1, 1] is mu-law quantized to
+    # [0, quantize_channels), conveted to one-hot vector and
+    # then fed to the network, otherwise fed directly to the network.
+    # NOTE: if you change the one of the two parameters below, then you need to
+    # re-run preprocessing.
+    mulaw=False,
+    quantize_channels=256,  # 65536 or 256
+
     # Audio:
-    quantize_channels=256,
-    sample_rate=22050,
+    sample_rate=16000,
+    # this is only valid for mulaw is True
     silence_threshold=2,
     num_mels=80,
     fft_size=1024,
@@ -29,7 +37,9 @@ hparams = tf.contrib.training.HParams(
     ref_level_db=20,
 
     # Model:
-    out_channels=256,
+    # This should equal to `quantize_channels` if mulaw enabled
+    # otherwise num_mixture * 3 (pi, mean, log_scale)
+    out_channels=10 * 3,
     layers=20,
     stacks=2,
     residual_channels=512,
@@ -88,7 +98,7 @@ hparams = tf.contrib.training.HParams(
     # Save
     # per-step intervals
     checkpoint_interval=10000,
-    train_eval_interval=10000,
+    train_eval_interval=3000,
     # per-epoch interval
     test_eval_epoch_interval=5,
     save_optimizer_state=True,

--- a/hparams.py
+++ b/hparams.py
@@ -99,6 +99,10 @@ hparams = tf.contrib.training.HParams(
     # if both are None, then full audio samples are used
     max_time_sec=None,
     max_time_steps=8000,
+    # Hold moving averaged parameters and use them for evaluation
+    exponential_moving_average=True,
+    # averaged = decay * averaged + (1 - decay) * x
+    ema_decay=0.9999,
 
     # Save
     # per-step intervals

--- a/hparams.py
+++ b/hparams.py
@@ -51,8 +51,8 @@ hparams = tf.contrib.training.HParams(
     # This should equal to `quantize_channels` if mu-law quantize enabled
     # otherwise num_mixture * 3 (pi, mean, log_scale)
     out_channels=10 * 3,
-    layers=20,
-    stacks=2,
+    layers=24,
+    stacks=4,
     residual_channels=512,
     gate_channels=512,  # split into 2 gropus internally for gated activation
     skip_out_channels=256,
@@ -90,7 +90,7 @@ hparams = tf.contrib.training.HParams(
     # Loss
 
     # Training:
-    batch_size=4,
+    batch_size=2,
     adam_beta1=0.9,
     adam_beta2=0.999,
     adam_eps=1e-8,
@@ -100,7 +100,7 @@ hparams = tf.contrib.training.HParams(
     lr_schedule_kwargs={},  # {"anneal_rate": 0.5, "anneal_interval": 50000},
     nepochs=2000,
     weight_decay=0.0,
-    clip_thresh=1.0,
+    clip_thresh=-1,
     # max time steps can either be specified as sec or steps
     # This is needed for those who don't have huge GPU memory...
     # if both are None, then full audio samples are used

--- a/ljspeech.py
+++ b/ljspeech.py
@@ -9,6 +9,8 @@ from hparams import hparams
 from os.path import exists
 import librosa
 
+from wavenet_vocoder.util import is_mulaw_quantize, is_mulaw, is_raw
+
 from hparams import hparams
 
 
@@ -32,7 +34,7 @@ def _process_utterance(out_dir, index, wav_path, text):
     wav = audio.load_wav(wav_path)
 
     # Mu-law quantize
-    if hparams.mulaw:
+    if is_mulaw_quantize(hparams.input_type):
         # [0, quantize_channels)
         out = P.mulaw_quantize(wav, hparams.quantize_channels)
 
@@ -40,8 +42,13 @@ def _process_utterance(out_dir, index, wav_path, text):
         start, end = audio.start_and_end_indices(out, hparams.silence_threshold)
         wav = wav[start:end]
         out = out[start:end]
-        constant_values = P.mulaw_quantize(0, quantize_channels)
+        constant_values = P.mulaw_quantize(0, hparams.quantize_channels)
         out_dtype = np.int16
+    elif is_mulaw(hparams.input_type):
+        # [-1, 1]
+        out = P.mulaw(wav, hparams.quantize_channels)
+        constant_values = P.mulaw(0.0, hparams.quantize_channels)
+        out_dtype = np.float32
     else:
         # [-1, 1]
         out = wav

--- a/ljspeech.py
+++ b/ljspeech.py
@@ -32,12 +32,21 @@ def _process_utterance(out_dir, index, wav_path, text):
     wav = audio.load_wav(wav_path)
 
     # Mu-law quantize
-    quantized = P.mulaw_quantize(wav, hparams.quantize_channels)
+    if hparams.mulaw:
+        # [0, quantize_channels)
+        out = P.mulaw_quantize(wav, hparams.quantize_channels)
 
-    # Trim silences
-    start, end = audio.start_and_end_indices(quantized, hparams.silence_threshold)
-    quantized = quantized[start:end]
-    wav = wav[start:end]
+        # Trim silences
+        start, end = audio.start_and_end_indices(out, hparams.silence_threshold)
+        wav = wav[start:end]
+        out = out[start:end]
+        constant_values = P.mulaw_quantize(0, quantize_channels)
+        out_dtype = np.int16
+    else:
+        # [-1, 1]
+        out = wav
+        constant_values = 0.0
+        out_dtype = np.float32
 
     # Compute a mel-scale spectrogram from the trimmed wav:
     # (N, D)
@@ -47,24 +56,23 @@ def _process_utterance(out_dir, index, wav_path, text):
     l, r = audio.lws_pad_lr(wav, hparams.fft_size, audio.get_hop_size())
 
     # zero pad for quantized signal
-    quantized = np.pad(quantized, (l, r), mode="constant",
-                       constant_values=P.mulaw_quantize(0, hparams.quantize_channels))
+    out = np.pad(out, (l, r), mode="constant", constant_values=constant_values)
     N = mel_spectrogram.shape[0]
-    assert len(quantized) >= N * audio.get_hop_size()
+    assert len(out) >= N * audio.get_hop_size()
 
     # time resolution adjastment
     # ensure length of raw audio is multiple of hop_size so that we can use
     # transposed convolution to upsample
-    quantized = quantized[:N * audio.get_hop_size()]
-    assert len(quantized) % audio.get_hop_size() == 0
+    out = out[:N * audio.get_hop_size()]
+    assert len(out) % audio.get_hop_size() == 0
 
-    timesteps = len(quantized)
+    timesteps = len(out)
 
     # Write the spectrograms to disk:
     audio_filename = 'ljspeech-audio-%05d.npy' % index
     mel_filename = 'ljspeech-mel-%05d.npy' % index
     np.save(os.path.join(out_dir, audio_filename),
-            quantized.astype(np.int16), allow_pickle=False)
+            out.astype(out_dtype), allow_pickle=False)
     np.save(os.path.join(out_dir, mel_filename),
             mel_spectrogram.astype(np.float32), allow_pickle=False)
 

--- a/ljspeech.py
+++ b/ljspeech.py
@@ -32,7 +32,7 @@ def _process_utterance(out_dir, index, wav_path, text):
     wav = audio.load_wav(wav_path)
 
     # Mu-law quantize
-    quantized = P.mulaw_quantize(wav)
+    quantized = P.mulaw_quantize(wav, hparams.quantize_channels)
 
     # Trim silences
     start, end = audio.start_and_end_indices(quantized, hparams.silence_threshold)
@@ -48,7 +48,7 @@ def _process_utterance(out_dir, index, wav_path, text):
 
     # zero pad for quantized signal
     quantized = np.pad(quantized, (l, r), mode="constant",
-                       constant_values=P.mulaw_quantize(0))
+                       constant_values=P.mulaw_quantize(0, hparams.quantize_channels))
     N = mel_spectrogram.shape[0]
     assert len(quantized) >= N * audio.get_hop_size()
 

--- a/synthesis.py
+++ b/synthesis.py
@@ -93,12 +93,12 @@ def wavegen(model, length=None, c=None, g=None, initial_value=None,
         c = Variable(torch.FloatTensor(c.T).unsqueeze(0))
 
     if initial_value is None:
-        initial_value = P.mulaw_quantize(0)  # dummy silence
-    assert initial_value >= 0 and initial_value < 256
+        initial_value = P.mulaw_quantize(0, hparams.quantize_channels)  # dummy silence
+    assert initial_value >= 0 and initial_value < hparams.quantize_channels
 
     initial_input = np_utils.to_categorical(
-        initial_value, num_classes=256).astype(np.float32)
-    initial_input = Variable(torch.from_numpy(initial_input)).view(1, 1, 256)
+        initial_value, num_classes=hparams.quantize_channels).astype(np.float32)
+    initial_input = Variable(torch.from_numpy(initial_input)).view(1, 1, hparams.quantize_channels)
     g = None if g is None else Variable(torch.LongTensor([g]))
     if use_cuda:
         initial_input = initial_input.cuda()
@@ -108,7 +108,7 @@ def wavegen(model, length=None, c=None, g=None, initial_value=None,
     y_hat = model.incremental_forward(
         initial_input, c=c, g=g, T=length, tqdm=tqdm, softmax=True, quantize=True)
     y_hat = y_hat.max(1)[1].view(-1).long().cpu().data.numpy()
-    y_hat = P.inv_mulaw_quantize(y_hat)
+    y_hat = P.inv_mulaw_quantize(y_hat, hparams.quantize_channels)
 
     return y_hat
 

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+from __future__ import with_statement, print_function, absolute_import
+
+import numpy as np
+import torch
+from torch import nn
+from torch.autograd import Variable
+from torch.nn import functional as F
+
+import librosa
+import pysptk
+
+from wavenet_vocoder.mixture import discretized_mix_logistic_loss
+from wavenet_vocoder.mixture import sample_from_discretized_mix_logistic
+
+
+def log_prob_from_logits(x):
+    """ numerically stable log_softmax implementation that prevents overflow """
+    # TF ordering
+    axis = len(x.size()) - 1
+    m, _ = torch.max(x, dim=-1, keepdim=True)
+    return x - m - torch.log(torch.sum(torch.exp(x - m), dim=axis, keepdim=True))
+
+
+def test_log_softmax():
+    x = Variable(torch.rand(2, 16000, 30))
+    y = log_prob_from_logits(x)
+    y_hat = F.log_softmax(x, -1)
+
+    y = y.data.cpu().numpy()
+    y_hat = y_hat.data.cpu().numpy()
+    assert np.allclose(y, y_hat)
+
+
+def test_mixture():
+    np.random.seed(1234)
+
+    x, sr = librosa.load(pysptk.util.example_audio_file(), sr=None)
+    assert sr == 16000
+
+    T = len(x)
+    x = x.reshape(1, T, 1)
+    y = Variable(torch.from_numpy(x)).float()
+    y_hat = Variable(torch.rand(1, 30, T)).float()
+
+    print(y.shape, y_hat.shape)
+
+    loss = discretized_mix_logistic_loss(y_hat, y)
+    print(loss)
+
+    loss = discretized_mix_logistic_loss(y_hat, y, reduce=False)
+    print(loss.size(), y.size())
+    assert loss.size() == y.size()
+
+    y = sample_from_discretized_mix_logistic(y_hat)
+    print(y.shape)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,7 +21,8 @@ use_cuda = False
 
 # For test
 build_compact_model = partial(WaveNet, layers=4, stacks=2, residual_channels=32,
-                              gate_channels=32, skip_out_channels=32, mulaw=True)
+                              gate_channels=32, skip_out_channels=32,
+                              scalar_input=False)
 
 # https://github.com/keras-team/keras/blob/master/keras/utils/np_utils.py
 # copied to avoid keras dependency in tests
@@ -111,7 +112,8 @@ def _test_data(sr=4000, N=3000, returns_power=False, mulaw=True):
 def test_mixture_wavenet():
     x, x_org, c = _test_data(returns_power=True, mulaw=False)
     # 10 mixtures
-    model = build_compact_model(out_channels=3 * 10, cin_channels=1, mulaw=False)
+    model = build_compact_model(out_channels=3 * 10, cin_channels=1,
+                                scalar_input=True)
     T = x.shape[-1]
     print(model.first_conv)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -21,7 +21,7 @@ use_cuda = False
 
 # For test
 build_compact_model = partial(WaveNet, layers=4, stacks=2, residual_channels=32,
-                              gate_channels=32, skip_out_channels=32)
+                              gate_channels=32, skip_out_channels=32, mulaw=True)
 
 # https://github.com/keras-team/keras/blob/master/keras/utils/np_utils.py
 # copied to avoid keras dependency in tests
@@ -68,7 +68,7 @@ def test_wavenet():
     print(y.size())
 
 
-def _quantized_test_data(sr=4000, N=3000, returns_power=False):
+def _test_data(sr=4000, N=3000, returns_power=False, mulaw=True):
     x, _ = librosa.load(example_audio_file(), sr=sr)
     x, _ = librosa.effects.trim(x, top_db=15)
 
@@ -90,13 +90,16 @@ def _quantized_test_data(sr=4000, N=3000, returns_power=False):
         p = p.reshape(1, 1, -1)
 
     # (T,)
-    x = P.mulaw_quantize(x)
-    x_org = P.inv_mulaw_quantize(x)
-
-    # (C, T)
-    x = to_categorical(x, num_classes=256).T
-    # (1, C, T)
-    x = x.reshape(1, 256, -1).astype(np.float32)
+    if mulaw:
+        x = P.mulaw_quantize(x)
+        x_org = P.inv_mulaw_quantize(x)
+        # (C, T)
+        x = to_categorical(x, num_classes=256).T
+        # (1, C, T)
+        x = x.reshape(1, 256, -1).astype(np.float32)
+    else:
+        x_org = x
+        x = x.reshape(1, 1, -1)
 
     if returns_power:
         return x, x_org, p
@@ -104,10 +107,43 @@ def _quantized_test_data(sr=4000, N=3000, returns_power=False):
     return x, x_org
 
 
+@attr("mixture")
+def test_mixture_wavenet():
+    x, x_org, c = _test_data(returns_power=True, mulaw=False)
+    # 10 mixtures
+    model = build_compact_model(out_channels=3 * 10, cin_channels=1, mulaw=False)
+    T = x.shape[-1]
+    print(model.first_conv)
+
+    # scalar input, not one-hot
+    assert x.shape[1] == 1
+
+    x = Variable(torch.from_numpy(x).contiguous())
+    x = x.cuda() if use_cuda else x
+
+    c = Variable(torch.from_numpy(c).contiguous())
+    c = c.cuda() if use_cuda else c
+    print(c.size())
+
+    model.eval()
+
+    # Incremental forward with forced teaching
+    y_online = model.incremental_forward(
+        test_inputs=x, c=c, T=None, tqdm=tqdm)
+
+    assert y_online.size() == x.size()
+
+    y_online2 = model.incremental_forward(
+        test_inputs=None, c=c, T=T, tqdm=tqdm)
+
+    assert y_online2.size() == x.size()
+    print(x.size())
+
+
 @attr("local_conditioning")
 def test_local_conditioning_correctness():
     # condition by power
-    x, x_org, c = _quantized_test_data(returns_power=True)
+    x, x_org, c = _test_data(returns_power=True)
     model = build_compact_model(cin_channels=1)
     assert model.local_conditioning_enabled()
     assert not model.has_speaker_embedding()
@@ -117,7 +153,7 @@ def test_local_conditioning_correctness():
 
     c = Variable(torch.from_numpy(c).contiguous())
     c = c.cuda() if use_cuda else c
-    print(c.size())
+    print(x.size(), c.size())
 
     model.eval()
 
@@ -142,7 +178,7 @@ def test_local_conditioning_correctness():
 @attr("local_conditioning")
 def test_local_conditioning_upsample_correctness():
     # condition by power
-    x, x_org, c = _quantized_test_data(returns_power=True)
+    x, x_org, c = _test_data(returns_power=True)
 
     # downsample by 4
     assert c.shape[-1] % 4 == 0
@@ -159,7 +195,7 @@ def test_local_conditioning_upsample_correctness():
 
     c = Variable(torch.from_numpy(c).contiguous())
     c = c.cuda() if use_cuda else c
-    print(c.size())
+    print(x.size(), c.size())
 
     model.eval()
 
@@ -184,7 +220,7 @@ def test_local_conditioning_upsample_correctness():
 @attr("global_conditioning")
 def test_global_conditioning_correctness():
     # condition by mean power
-    x, x_org, c = _quantized_test_data(returns_power=True)
+    x, x_org, c = _test_data(returns_power=True)
     g = c.mean(axis=-1, keepdims=True).astype(np.int)
     model = build_compact_model(gin_channels=16, n_speakers=256)
     assert not model.local_conditioning_enabled()
@@ -219,7 +255,7 @@ def test_global_conditioning_correctness():
 
 @attr("local_and_global_conditioning")
 def test_global_and_local_conditioning_correctness():
-    x, x_org, c = _quantized_test_data(returns_power=True)
+    x, x_org, c = _test_data(returns_power=True)
     g = c.mean(axis=-1, keepdims=True).astype(np.int)
     model = build_compact_model(cin_channels=1, gin_channels=16, n_speakers=256)
     assert model.local_conditioning_enabled()
@@ -275,7 +311,7 @@ def test_incremental_forward_correctness():
         model = model.cuda()
 
     sr = 4000
-    x, x_org = _quantized_test_data(sr=sr, N=3000)
+    x, x_org = _test_data(sr=sr, N=3000)
     x = Variable(torch.from_numpy(x).contiguous())
     x = x.cuda() if use_cuda else x
 

--- a/train.py
+++ b/train.py
@@ -492,6 +492,7 @@ def eval_model(global_step, writer, model, y, c, g, input_lengths, eval_dir):
         y_target = P.inv_mulaw_quantize(y_target, hparams.quantize_channels)
     elif is_mulaw(hparams.input_type):
         y_hat = P.inv_mulaw(y_hat.view(-1).cpu().data.numpy(), hparams.quantize_channels)
+        y_target = P.inv_mulaw(y_target, hparams.quantize_channels)
     else:
         y_hat = y_hat.view(-1).cpu().data.numpy()
 

--- a/train.py
+++ b/train.py
@@ -635,6 +635,7 @@ def save_checkpoint(model, optimizer, step, checkpoint_dir, epoch):
 
 def build_model():
     model = getattr(builder, hparams.builder)(
+        out_channels=hparams.out_channels,
         layers=hparams.layers,
         stacks=hparams.stacks,
         residual_channels=hparams.residual_channels,

--- a/train.py
+++ b/train.py
@@ -468,7 +468,7 @@ def eval_model(global_step, writer, model, y, c, g, input_lengths, eval_dir):
     # Dummy silence
     if is_mulaw_quantize(hparams.input_type):
         initial_value = P.mulaw_quantize(0, hparams.quantize_channels)
-    elif hparams.is_mulaw(hparams.input_type):
+    elif is_mulaw(hparams.input_type):
         initial_value = P.mulaw(0.0, hparams.quantize_channels)
     else:
         initial_value = 0.0
@@ -490,7 +490,7 @@ def eval_model(global_step, writer, model, y, c, g, input_lengths, eval_dir):
         y_hat = y_hat.max(1)[1].view(-1).long().cpu().data.numpy()
         y_hat = P.inv_mulaw_quantize(y_hat, hparams.quantize_channels)
         y_target = P.inv_mulaw_quantize(y_target, hparams.quantize_channels)
-    elif hparams.is_mulaw(hparams.input_type):
+    elif is_mulaw(hparams.input_type):
         y_hat = P.inv_mulaw(y_hat.view(-1).cpu().data.numpy(), hparams.quantize_channels)
     else:
         y_hat = y_hat.view(-1).cpu().data.numpy()
@@ -533,7 +533,7 @@ def save_states(global_step, writer, y_hat, y, input_lengths, checkpoint_dir=Non
         y_hat = y_hat[idx].view(-1).data.cpu().numpy()
         y = y[idx].view(-1).data.cpu().numpy()
 
-        if hparams.is_mulaw(hparams.input_type):
+        if is_mulaw(hparams.input_type):
             y_hat = P.inv_mulaw(y_hat, hparams.quantize_channels)
             y = P.inv_mulaw(y, hparams.quantize_channels)
 

--- a/train.py
+++ b/train.py
@@ -286,11 +286,14 @@ class ExponentialMovingAverage(object):
 
 def clone_as_averaged_model(model, ema):
     assert ema is not None
-    model = model.clone()
-    for name, param in model.named_parameters():
+    averaged_model = build_model()
+    if use_cuda:
+        averaged_model = averaged_model.cuda()
+    averaged_model.load_state_dict(model.state_dict())
+    for name, param in averaged_model.named_parameters():
         if name in ema.shadow:
             param.data = ema.shadow[name].clone()
-    return model
+    return averaged_model
 
 
 class MaskedCrossEntropyLoss(nn.Module):

--- a/wavenet_vocoder/builder.py
+++ b/wavenet_vocoder/builder.py
@@ -2,7 +2,8 @@
 from __future__ import with_statement, print_function, absolute_import
 
 
-def wavenet(layers=20,
+def wavenet(out_channels=256,
+            layers=20,
             stacks=2,
             residual_channels=512,
             gate_channels=512,
@@ -19,7 +20,7 @@ def wavenet(layers=20,
             ):
     from wavenet_vocoder import WaveNet
 
-    model = WaveNet(layers=layers, stacks=stacks,
+    model = WaveNet(out_channels=out_channels, layers=layers, stacks=stacks,
                     residual_channels=residual_channels,
                     gate_channels=gate_channels,
                     skip_out_channels=skip_out_channels,

--- a/wavenet_vocoder/builder.py
+++ b/wavenet_vocoder/builder.py
@@ -17,6 +17,7 @@ def wavenet(out_channels=256,
             upsample_conditional_features=False,
             upsample_scales=[16, 16],
             freq_axis_kernel_size=3,
+            mulaw=True,
             ):
     from wavenet_vocoder import WaveNet
 
@@ -31,6 +32,7 @@ def wavenet(out_channels=256,
                     upsample_conditional_features=upsample_conditional_features,
                     upsample_scales=upsample_scales,
                     freq_axis_kernel_size=freq_axis_kernel_size,
+                    mulaw=mulaw,
                     )
 
     return model

--- a/wavenet_vocoder/builder.py
+++ b/wavenet_vocoder/builder.py
@@ -17,7 +17,7 @@ def wavenet(out_channels=256,
             upsample_conditional_features=False,
             upsample_scales=[16, 16],
             freq_axis_kernel_size=3,
-            mulaw=True,
+            scalar_input=False,
             ):
     from wavenet_vocoder import WaveNet
 
@@ -32,7 +32,7 @@ def wavenet(out_channels=256,
                     upsample_conditional_features=upsample_conditional_features,
                     upsample_scales=upsample_scales,
                     freq_axis_kernel_size=freq_axis_kernel_size,
-                    mulaw=mulaw,
+                    scalar_input=scalar_input,
                     )
 
     return model

--- a/wavenet_vocoder/mixture.py
+++ b/wavenet_vocoder/mixture.py
@@ -1,0 +1,141 @@
+# coding: utf-8
+# Code is adapted from:
+# https://github.com/pclucas14/pixel-cnn-pp
+# https://github.com/openai/pixel-cnn
+
+from __future__ import with_statement, print_function, absolute_import
+
+import math
+import numpy as np
+
+import torch
+from torch import nn
+from torch.autograd import Variable
+from torch.nn import functional as F
+
+
+def log_sum_exp(x):
+    """ numerically stable log_sum_exp implementation that prevents overflow """
+    # TF ordering
+    axis = len(x.size()) - 1
+    m, _ = torch.max(x, dim=axis)
+    m2, _ = torch.max(x, dim=axis, keepdim=True)
+    return m + torch.log(torch.sum(torch.exp(x - m2), dim=axis))
+
+
+def discretized_mix_logistic_loss(y_hat, y, num_classes=256, reduce=True):
+    """Discretized mixture of logistic distributions loss
+
+    Note that it is assumed that input is scaled to [-1, 1].
+
+    Args:
+        y_hat (Variable): Predicted output (B x C x T)
+        y (Variable): Target (B x T x 1).
+    Returns
+        Variable: loss
+    """
+    assert y_hat.dim() == 3
+    assert y_hat.size(1) % 3 == 0
+    nr_mix = y_hat.size(1) // 3
+
+    # (B x T x C)
+    y_hat = y_hat.transpose(1, 2)
+
+    # unpack parameters. (B, T, num_mixtures) x 3
+    logit_probs = y_hat[:, :, :nr_mix]
+    means = y_hat[:, :, nr_mix:2 * nr_mix]
+    log_scales = torch.clamp(y_hat[:, :, 2 * nr_mix:3 * nr_mix], min=-7.0)
+
+    # B x T x 1 -> B x T x num_mixtures
+    y = y.expand_as(means)
+
+    centered_y = y - means
+    inv_stdv = torch.exp(-log_scales)
+    plus_in = inv_stdv * (centered_y + 1. / (num_classes - 1))
+    cdf_plus = F.sigmoid(plus_in)
+    min_in = inv_stdv * (centered_y - 1. / (num_classes - 1))
+    cdf_min = F.sigmoid(min_in)
+
+    # わからん
+    # log probability for edge case of 0 (before scaling)
+    log_cdf_plus = plus_in - F.softplus(plus_in)
+    # わからん
+    # log probability for edge case of 255 (before scaling)
+    log_one_minus_cdf_min = -F.softplus(min_in)
+    # わかる
+    # probability for all other cases
+    cdf_delta = cdf_plus - cdf_min
+
+    mid_in = inv_stdv * centered_y
+    # log probability in the center of the bin, to be used in extreme cases
+    # (not actually used in our code)
+    log_pdf_mid = mid_in - log_scales - 2. * F.softplus(mid_in)
+
+    # tf equivalent
+    """
+    log_probs = tf.where(x < -0.999, log_cdf_plus,
+                         tf.where(x > 0.999, log_one_minus_cdf_min,
+                                  tf.where(cdf_delta > 1e-5,
+                                           tf.log(tf.maximum(cdf_delta, 1e-12)),
+                                           log_pdf_mid - np.log(127.5))))
+    """
+    inner_inner_cond = (cdf_delta > 1e-5).float()
+    inner_inner_out = inner_inner_cond * \
+        torch.log(torch.clamp(cdf_delta, min=1e-12)) + \
+        (1. - inner_inner_cond) * (log_pdf_mid - np.log(127.5))
+    inner_cond = (y > 0.999).float()
+    inner_out = inner_cond * log_one_minus_cdf_min + (1. - inner_cond) * inner_inner_out
+    cond = (y < -0.999).float()
+    log_probs = cond * log_cdf_plus + (1. - cond) * inner_out
+
+    log_probs = torch.sum(log_probs, dim=-1, keepdim=True) + F.log_softmax(logit_probs, -1)
+
+    if reduce:
+        return -torch.sum(log_sum_exp(log_probs))
+    else:
+        return -log_sum_exp(log_probs).unsqueeze(-1)
+
+
+def to_one_hot(tensor, n, fill_with=1.):
+    # we perform one hot encore with respect to the last axis
+    one_hot = torch.FloatTensor(tensor.size() + (n,)).zero_()
+    if tensor.is_cuda:
+        one_hot = one_hot.cuda()
+    one_hot.scatter_(len(tensor.size()), tensor.unsqueeze(-1), fill_with)
+    return Variable(one_hot)
+
+
+def sample_from_discretized_mix_logistic(y):
+    """
+    Args:
+        y (Variable): B x C x T
+
+    Returns:
+        Variable: sample in range of [-1, 1].
+    """
+    assert y.size(1) % 3 == 0
+    nr_mix = y.size(1) // 3
+
+    # B x T x C
+    y = y.transpose(1, 2)
+    logit_probs = y[:, :, :nr_mix]
+
+    # sample mixture indicator from softmax
+    temp = logit_probs.data.new(logit_probs.size()).uniform_(1e-5, 1.0 - 1e-5)
+    temp = logit_probs.data - torch.log(- torch.log(temp))
+    _, argmax = temp.max(dim=-1)
+
+    # (B, T) -> (B, T, nr_mix)
+    one_hot = to_one_hot(argmax, nr_mix)
+    # select logistic parameters
+    means = torch.sum(y[:, :, nr_mix:2 * nr_mix] * one_hot, dim=-1)
+    log_scales = torch.clamp(torch.sum(
+        y[:, :, 2 * nr_mix:3 * nr_mix] * one_hot, dim=-1), min=-7.0)
+    # sample from logistic & clip to interval
+    # we don't actually round to the nearest 8bit value when sampling
+    u = Variable(means.data.new(means.size()).uniform_(1e-5, 1.0 - 1e-5))
+    x = means + torch.exp(log_scales) * (torch.log(u) - torch.log(1. - u))
+
+    x = torch.clamp(torch.clamp(x, min=-1.), max=1.)
+
+    return x

--- a/wavenet_vocoder/modules.py
+++ b/wavenet_vocoder/modules.py
@@ -10,15 +10,14 @@ from torch.autograd import Variable
 from torch.nn import functional as F
 
 
-def Conv1d1x1(in_channels, out_channels, bias=True, weight_normalization=True,
-              dropout=0.):
+def Conv1d1x1(in_channels, out_channels, bias=True, weight_normalization=True):
     """1-by-1 convolution layer
     """
     if weight_normalization:
         from deepvoice3_pytorch.modules import Conv1d
         assert bias
         return Conv1d(in_channels, out_channels, kernel_size=1, padding=0,
-                      dilation=1, bias=bias, std_mul=1.0, dropout=dropout)
+                      dilation=1, bias=bias, std_mul=1.0)
     else:
         from deepvoice3_pytorch.conv import Conv1d
         return Conv1d(in_channels, out_channels, kernel_size=1, padding=0,
@@ -60,7 +59,7 @@ class ResidualConv1dGLU(nn.Module):
             from deepvoice3_pytorch.modules import Conv1d
             assert bias
             self.conv = Conv1d(residual_channels, gate_channels, kernel_size,
-                               padding=padding, dilation=dilation,
+                               dropout=dropout, padding=padding, dilation=dilation,
                                bias=bias, std_mul=1.0, *args, **kwargs)
         else:
             from deepvoice3_pytorch.conv import Conv1d
@@ -109,6 +108,7 @@ class ResidualConv1dGLU(nn.Module):
             Variable: output
         """
         residual = x
+        x = F.dropout(x, p=self.dropout, training=self.training)
         if is_incremental:
             splitdim = -1
             x = self.conv.incremental_forward(x)
@@ -117,7 +117,6 @@ class ResidualConv1dGLU(nn.Module):
             x = self.conv(x)
             # remove future time steps
             x = x[:, :, :residual.size(-1)] if self.causal else x
-        x = F.dropout(x, p=self.dropout, training=self.training)
 
         a, b = x.split(x.size(splitdim) // 2, dim=splitdim)
 

--- a/wavenet_vocoder/modules.py
+++ b/wavenet_vocoder/modules.py
@@ -10,6 +10,18 @@ from torch.autograd import Variable
 from torch.nn import functional as F
 
 
+def ConvTranspose2d(in_channels, out_channels, kernel_size,
+                    weight_normalization=True, **kwargs):
+    freq_axis_kernel_size = kernel_size[0]
+    m = nn.ConvTranspose2d(in_channels, out_channels, kernel_size, **kwargs)
+    m.weight.data.fill_(1.0 / freq_axis_kernel_size)
+    m.bias.data.zero_()
+    if weight_normalization:
+        return nn.utils.weight_norm(m)
+    else:
+        return m
+
+
 def Conv1d1x1(in_channels, out_channels, bias=True, weight_normalization=True):
     """1-by-1 convolution layer
     """

--- a/wavenet_vocoder/util.py
+++ b/wavenet_vocoder/util.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+from __future__ import with_statement, print_function, absolute_import
+
+
+def _assert_valid_input_type(s):
+    assert s == "mulaw-quantize" or s == "mulaw" or s == "raw"
+
+
+def is_mulaw_quantize(s):
+    _assert_valid_input_type(s)
+    return s == "mulaw-quantize"
+
+
+def is_mulaw(s):
+    _assert_valid_input_type(s)
+    return s == "mulaw"
+
+
+def is_raw(s):
+    _assert_valid_input_type(s)
+    return s == "raw"
+
+
+def is_scalar_input(s):
+    return is_raw(s) or is_mulaw(s)

--- a/wavenet_vocoder/wavenet.py
+++ b/wavenet_vocoder/wavenet.py
@@ -11,7 +11,7 @@ from torch.nn import functional as F
 
 from deepvoice3_pytorch.modules import Embedding
 
-from .modules import Conv1d1x1, ResidualConv1dGLU
+from .modules import Conv1d1x1, ResidualConv1dGLU, ConvTranspose2d
 from .mixture import sample_from_discretized_mix_logistic
 
 
@@ -122,14 +122,11 @@ class WaveNet(nn.Module):
             self.upsample_conv = nn.ModuleList()
             for s in upsample_scales:
                 freq_axis_padding = (freq_axis_kernel_size - 1) // 2
-                convt = nn.ConvTranspose2d(1, 1, kernel_size=(
-                    freq_axis_kernel_size, s), padding=(freq_axis_padding, 0),
-                    dilation=1, stride=(1, s))
-                convt.bias.data.zero_()
-                convt.weight.data.fill_(1.0 / freq_axis_kernel_size)
+                convt = ConvTranspose2d(1, 1, (freq_axis_kernel_size, s),
+                                        padding=(freq_axis_padding, 0),
+                                        dilation=1, stride=(1, s),
+                                        weight_normalization=weight_normalization)
                 self.upsample_conv.append(convt)
-                # Is this non-lineality necessary?
-                # self.upsample_conv.append(nn.ReLU(inplace=True))
         else:
             self.upsample_conv = None
 

--- a/wavenet_vocoder/wavenet.py
+++ b/wavenet_vocoder/wavenet.py
@@ -127,6 +127,9 @@ class WaveNet(nn.Module):
                                         dilation=1, stride=(1, s),
                                         weight_normalization=weight_normalization)
                 self.upsample_conv.append(convt)
+                # assuming we use [0, 1] scaled features
+                # this should avoid non-negative upsampling output
+                self.upsample_conv.append(nn.ReLU(inplace=True))
         else:
             self.upsample_conv = None
 


### PR DESCRIPTION
- Add `mixture` module, which implements `discretized_mix_logistic_loss` and `sample_from_discretized_mix_logistic`.
- mu-law quantization (8bit) and 16-bit linear PCM are now supported. 

The code was adapted from https://github.com/openai/pixel-cnn and https://github.com/pclucas14/pixel-cnn-pp. 