### PR TITLE
Remove math.sqrt(0.5) from skip connections.

### DIFF
--- a/wavenet_vocoder/wavenet.py
+++ b/wavenet_vocoder/wavenet.py
@@ -221,8 +221,6 @@ class WaveNet(nn.Module):
                 skips = h
             else:
                 skips += h
-                skips *= math.sqrt(0.5)
-            # skips = h if skips is None else (skips + h) * math.sqrt(0.5)
 
         x = skips
         for f in self.last_conv_layers:
@@ -333,7 +331,7 @@ class WaveNet(nn.Module):
             skips = None
             for f in self.conv_layers:
                 x, h = f.incremental_forward(x, ct, gt)
-                skips = h if skips is None else (skips + h) * math.sqrt(0.5)
+                skips = h if skips is None else (skips + h)
             x = skips
             for f in self.last_conv_layers:
                 try:


### PR DESCRIPTION
Both the Deep Voice paper and the Fair Seq2Seq paper advocate for ``math.sqrt(0.5)`` to keep the variance stable for the output of residual blocks. That ``math.sqrt(0.5)`` is kept.

For Wavenet, you are summing 24 layers together; therefore, to keep the variance stable you'd need to multiply by ``math.sqrt(1/24)`` to achieve the same effect. Meanwhile, since I have not seen something like ``math.sqrt(1/24)`` used, I removed ``math.sqrt(0.5)``.