### PR TITLE
Add --preset parameter to evaluate.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Usage:
 
 ```
 python evaluate.py ${checkpoint_path} ${output_dir} --data-root="data location"\
-    --hparams="parameters you want to override"
+    --preset=<json> --hparams="parameters you want to override"
 ```
 
 This script is used for generating sounds for https://r9y9.github.io/wavenet_vocoder/.

--- a/evaluate.py
+++ b/evaluate.py
@@ -7,6 +7,7 @@ usage: evaluate.py [options] <checkpoint> <dst_dir>
 options:
     --data-root=<dir>           Directory contains preprocessed features.
     --hparams=<parmas>          Hyper parameters [default: ].
+    --preset=<json>             Path of preset parameters (json).
     --length=<T>                Steps to generate [default: 32000].
     --speaker-id=<N>            Use specific speaker of data in case for multi-speaker datasets.
     --initial-value=<n>         Initial value for the WaveNet decoder.
@@ -56,7 +57,12 @@ if __name__ == "__main__":
     file_name_suffix = args["--file-name-suffix"]
     output_html = args["--output-html"]
     num_utterances = int(args["--num-utterances"])
+    preset = args["--preset"]
 
+    # Load preset if specified
+    if preset is not None:
+        with open(preset) as f:
+            hparams.parse_json(f.read())
     # Override hyper parameters
     hparams.parse(args["--hparams"])
     assert hparams.name == "wavenet_vocoder"


### PR DESCRIPTION
Used a preset for training. Afterwards when tried to use evaluate.py it was unintuitive/inconvinient to specify hparams in commandline. 